### PR TITLE
Support memoized config

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,9 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "ensure-array": "^1.0.0",
+    "lodash.isequal": "^4.0.0",
     "lodash.throttle": "^4.0.0",
+    "micro-memoize": "^4.0.8",
     "prop-types": "^15.6.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "react-bootstrap-buttons": "~0.5.0",
     "react-dom": "~16.8.0",
     "react-github-corner": "~2.3.0",
-    "react-styleguidist": "~9.1.11",
+    "react-styleguidist": "~9.0.4",
     "redux": "~4.0.4",
     "resize-observer-polyfill": "~1.5.1",
     "style-loader": "~0.23.1",

--- a/src/Container.jsx
+++ b/src/Container.jsx
@@ -13,6 +13,7 @@ import {
 } from './constants';
 import Resolver from './Resolver';
 import { ConfigurationContext } from './context';
+import { getMemoizedConfig } from './utils';
 import styles from './index.styl';
 
 class Container extends PureComponent {
@@ -129,18 +130,11 @@ class Container extends PureComponent {
                         const { layout = config.layout } = this.props;
                         return (LAYOUTS.indexOf(layout) >= 0) ? layout : DEFAULT_LAYOUT;
                     })();
+                    const memoizedConfig = getMemoizedConfig({ containerWidths, columns, gutterWidth, layout });
                     const containerStyle = this.getStyle({ containerWidths, gutterWidth, screenClass });
 
                     return (
-                        <ConfigurationContext.Provider
-                            value={{
-                                ...config,
-                                containerWidths,
-                                columns,
-                                gutterWidth,
-                                layout,
-                            }}
-                        >
+                        <ConfigurationContext.Provider value={memoizedConfig}>
                             <div
                                 {...props}
                                 className={cx(className, {

--- a/src/Provider.jsx
+++ b/src/Provider.jsx
@@ -1,5 +1,5 @@
 import ensureArray from 'ensure-array';
-import throttle from 'lodash.throttle';
+import _throttle from 'lodash.throttle';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import {
@@ -12,7 +12,7 @@ import {
     DEFAULT_LAYOUT,
 } from './constants';
 import { ConfigurationContext, ScreenClassContext } from './context';
-import { getScreenClass } from './utils';
+import { getMemoizedConfig, getScreenClass } from './utils';
 
 class Provider extends PureComponent {
     static propTypes = {
@@ -55,7 +55,7 @@ class Provider extends PureComponent {
     componentDidMount() {
         this.setScreenClass();
 
-        this.eventListener = throttle(this.setScreenClass, Math.floor(1000 / 60)); // 60Hz
+        this.eventListener = _throttle(this.setScreenClass, Math.floor(1000 / 60)); // 60Hz
         window.addEventListener('resize', this.eventListener);
     }
 
@@ -76,10 +76,6 @@ class Provider extends PureComponent {
     };
 
     render() {
-        const breakpoints = (() => {
-            const breakpoints = ensureArray(this.props.breakpoints);
-            return breakpoints.length > 0 ? breakpoints : DEFAULT_BREAKPOINTS;
-        })();
         const containerWidths = (() => {
             const containerWidths = ensureArray(this.props.containerWidths);
             return containerWidths.length > 0 ? containerWidths : DEFAULT_CONTAINER_WIDTHS;
@@ -96,18 +92,11 @@ class Provider extends PureComponent {
             const layout = this.props.layout;
             return (LAYOUTS.indexOf(layout) >= 0) ? layout : DEFAULT_LAYOUT;
         })();
+        const memoizedConfig = getMemoizedConfig({ containerWidths, columns, gutterWidth, layout });
         const { screenClass } = this.state;
 
         return (
-            <ConfigurationContext.Provider
-                value={{
-                    breakpoints,
-                    containerWidths,
-                    columns,
-                    gutterWidth,
-                    layout,
-                }}
-            >
+            <ConfigurationContext.Provider value={memoizedConfig}>
                 <ScreenClassContext.Provider value={screenClass}>
                     <React.Fragment>
                         {this.props.children}

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,6 @@
 import ensureArray from 'ensure-array';
+import _isEqual from 'lodash.isequal';
+import memoize from 'micro-memoize';
 import {
     DEFAULT_BREAKPOINTS
 } from './constants';
@@ -9,6 +11,24 @@ export const getViewportWidth = () => {
     }
     return null;
 };
+
+export const getMemoizedConfig = memoize(config => {
+    const {
+        containerWidths,
+        columns,
+        gutterWidth,
+        layout,
+    } = { ...config };
+
+    return {
+        containerWidths,
+        columns,
+        gutterWidth,
+        layout,
+    };
+}, {
+    isEqual: _isEqual,
+});
 
 export const getScreenClass = ({ breakpoints }) => {
     breakpoints = ensureArray(breakpoints);

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -2,6 +2,7 @@ const path = require('path');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const webpack = require('webpack');
 const pkg = require('./package.json');
+const babelConfig = require('./babel.config');
 
 const webpackConfig = {
     mode: 'development',
@@ -22,7 +23,10 @@ const webpackConfig = {
             {
                 test: /\.jsx?$/,
                 loader: 'babel-loader',
-                exclude: /node_modules/
+                // XXX: due to untranspiled code in styleguide's node_modules, it needs to include them
+                // https://github.com/styleguidist/react-styleguidist/blob/f14e8e7f403aa32045b9f61e4e4f1a7776146d8b/examples/ie11/styleguide.config.js#L4
+                exclude: /node_modules\/(?!(ansi-styles|strip-ansi|ansi-regex|react-dev-utils|chalk|regexpu-core|unicode-match-property-ecmascript|unicode-match-property-value-ecmascript|acorn-jsx)\/).*/,
+                options: babelConfig
             },
             {
                 test: /\.styl$/,


### PR DESCRIPTION
React context uses reference identity to determine when to re-render, this PR uses a memoized method to return the previously calculated result to avoid unintentional renders in consumers when a provider's parent re-renders.
